### PR TITLE
Patch GCSORT to compile on OS X

### DIFF
--- a/packages/0001-gcsort-conditionally-include-os-x-headers.patch
+++ b/packages/0001-gcsort-conditionally-include-os-x-headers.patch
@@ -1,0 +1,47 @@
+From b301ab5a260884aab8255cad1fa5c2515399fd63 Mon Sep 17 00:00:00 2001
+From: Alex Kwiatkowski <alex+git@fremantle.io>
+Date: Sat, 23 Nov 2024 17:04:26 -0800
+Subject: [PATCH] conditionally include os x headers
+
+---
+ copyfile.h | 6 +++++-
+ job.h      | 6 +++++-
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/copyfile.h b/copyfile.h
+index e699b1c..8150443 100644
+--- a/copyfile.h
++++ b/copyfile.h
+@@ -32,7 +32,11 @@
+ 	#define _strtoll    _strtoi64
+ #else
+ 	#include <limits.h>
+-	#include <sys/io.h>
++#ifdef __APPLE__
++  #include <sys/uio.h>
++#else
++  #include <sys/io.h>
++#endif
+ 	#include <time.h>
+ 	#include <fcntl.h>
+ 	#define _strtoll   strtoll
+diff --git a/job.h b/job.h
+index f6d002d..c95b76b 100644
+--- a/job.h
++++ b/job.h
+@@ -34,7 +34,11 @@
+ 	/* #define GCThread __declspec( thread ) */
+ #else
+ 	#include <limits.h>
+-	#include <sys/io.h>
++#ifdef __APPLE__
++  #include <sys/uio.h>
++#else
++  #include <sys/io.h>
++#endif
+ 	#include <time.h>
+ 	#include <fcntl.h>
+ 	#define _strtoll   strtoll
+-- 
+2.46.0
+

--- a/packages/0002-gcsort-comment-include-malloc.h.patch
+++ b/packages/0002-gcsort-comment-include-malloc.h.patch
@@ -1,0 +1,53 @@
+From 9f4ba6c4b0dfe73c9ef5accd3b08fb3ea1be6198 Mon Sep 17 00:00:00 2001
+From: Alex Kwiatkowski <alex+git@fremantle.io>
+Date: Sat, 23 Nov 2024 21:19:23 -0800
+Subject: [PATCH] comment include malloc.h
+
+---
+ copyfile.c | 2 +-
+ job.c      | 2 +-
+ outfil.c   | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tools/GCSORT/copyfile.c b/tools/GCSORT/copyfile.c
+index 51ce01b..4f0bdf2 100644
+--- a/copyfile.c
++++ b/copyfile.c
+@@ -19,7 +19,7 @@
+ */
+  
+ #include <sys/stat.h>
+-#include <malloc.h>
++/* #include <malloc.h> */
+ #include <time.h>
+ #include <ctype.h>
+ 
+diff --git a/job.c b/job.c
+index 62e968b..dec9e36 100644
+--- a/job.c
++++ b/job.c
+@@ -20,7 +20,7 @@
+ */
+ #define _GNU_SOURCE
+ #include <sys/stat.h>
+-#include <malloc.h>
++/* #include <malloc.h> */
+ #include <time.h>
+ #include <ctype.h>
+ 
+diff --git a/outfil.c b/outfil.c
+index 46ff471..f3eee6b 100644
+--- a/outfil.c
++++ b/outfil.c
+@@ -25,7 +25,7 @@
+ #include <sys/stat.h>
+ #include <math.h>
+ #include <limits.h>
+-#include <malloc.h>
++/* #include <malloc.h> */
+ #include <time.h>
+ #include "libgcsort.h"
+ #include <string.h>
+-- 
+2.46.0
+

--- a/packages/0003-use-posix-definitions-for-stat-values.patch
+++ b/packages/0003-use-posix-definitions-for-stat-values.patch
@@ -1,0 +1,27 @@
+From eba1223b7ef7c404dbcba165f61dae8ad12fc389 Mon Sep 17 00:00:00 2001
+From: Porter Jones <porter@mechanical-orchard.com>
+Date: Tue, 3 Dec 2024 10:08:29 -0800
+Subject: [PATCH] Use posix definitions for stat values
+
+---
+ utils.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/utils.h b/utils.h
+index 39274c6..14e4d78 100644
+--- a/utils.h
++++ b/utils.h
+@@ -46,8 +46,8 @@
+ 	#if !defined(__MINGW32__) && !defined(__MINGW64__)
+ 		typedef int HANDLE;
+ 		#define INVALID_HANDLE_VALUE 0
+-		#define _S_IREAD	__S_IREAD
+-		#define _S_IWRITE	__S_IWRITE
++		#define _S_IREAD	S_IRUSR
++		#define _S_IWRITE	S_IWUSR
+ 
+ 		#define _O_TRUNC 	O_TRUNC
+ 		#define _O_RDONLY	O_RDONLY
+-- 
+2.45.1
+

--- a/packages/gcsort.nix
+++ b/packages/gcsort.nix
@@ -36,6 +36,7 @@ in
     patches = [
       ./0001-gcsort-conditionally-include-os-x-headers.patch
       ./0002-gcsort-comment-include-malloc.h.patch
+      ./0003-use-posix-definitions-for-stat-values.patch
     ];
 
     buildPhase = ''

--- a/packages/gcsort.nix
+++ b/packages/gcsort.nix
@@ -24,31 +24,30 @@ in
     version = args.version;
     src = "${repo}/tools/GCSORT";
 
-    nativeBuildInputs = [
-    ];
+    nativeBuildInputs = [];
 
     buildInputs =
       [
         pkgs.gnucobol-pkgs.gnucobol.dev
         pkgs.gnucobol-pkgs.gnucobol.lib
       ]
-      ++ pkgs.lib.optional pkgs.stdenv.isDarwin [
-      ];
+      ++ pkgs.lib.optional pkgs.stdenv.isDarwin [];
+
+    patches = [
+      ./0001-gcsort-conditionally-include-os-x-headers.patch
+      ./0002-gcsort-comment-include-malloc.h.patch
+    ];
 
     buildPhase = ''
       runHook preBuild
-
       make
-
       runHook postBuild
     '';
 
     installPhase = ''
       runHook preInstall
-
       mkdir -p $out/bin
       mv gcsort $out/bin
-
       runHook postInstall
     '';
 


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Conditionally include OS X-specific headers, comment out unused `malloc.h` includes, apply POSIX definitions for file attributes, and add relevant patches for compiling GCSORT on OS X.

### Why are these changes being made?

These changes address compatibility issues on OS X by including appropriate system headers and replacing platform-specific file attribute definitions with their POSIX equivalents. OS X does not require explicit `malloc.h` inclusion, which prevents compilation errors. The changes ensure GCSORT can be compiled and execute properly on OS X systems by pulling the necessary patches into the build process.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->