### PR TITLE
Include custom header for all aarch64 systems, not just Mac

### DIFF
--- a/packages/0001-gcsort-conditionally-include-os-x-headers.patch
+++ b/packages/0001-gcsort-conditionally-include-os-x-headers.patch
@@ -17,7 +17,7 @@ index e699b1c..8150443 100644
  #else
  	#include <limits.h>
 -	#include <sys/io.h>
-+#ifdef __APPLE__
++#ifdef __aarch64__
 +  #include <sys/uio.h>
 +#else
 +  #include <sys/io.h>
@@ -34,7 +34,7 @@ index f6d002d..c95b76b 100644
  #else
  	#include <limits.h>
 -	#include <sys/io.h>
-+#ifdef __APPLE__
++#ifdef __aarch64__
 +  #include <sys/uio.h>
 +#else
 +  #include <sys/io.h>


### PR DESCRIPTION
Prior to this we could not build aarch64 images on linux - it appears that this header file doesn't exist on aarch64 ubuntu either (at least according to [this](https://github.com/open62541/open62541/issues/4345)).