### PR TITLE
Build/publish an image with /nix/store-gcsort dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ RUN \
     --show-trace \
     --log-format raw \
     build .#gcsort --out-link /tmp/output/gcsort
+  cp -R $(nix-store -qR /tmp/output/gcsort) /tmp/nix-store-closure-gcsort
   cp -R $(nix-store -qR /tmp/output/gcsort) /tmp/nix-store-closure
 EOF
 # esqloc
@@ -96,5 +97,6 @@ EOF
 
 FROM alpine
 WORKDIR /app
+COPY --from=builder /tmp/nix-store-closure-gcsort /nix/store-gcsort
 COPY --from=builder /tmp/nix-store-closure /nix/store
 COPY --from=builder /tmp/output/ /app/


### PR DESCRIPTION
So that other Dockerfiles can copy in just the dependencies for gcsort and not pick up dependencies for other binaries in the 'global' store.